### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Focuslight is currently lacking some GrowthForecast features:
 
 RRDTool and its dependencies must be installed before installing Focuslight.
 
-* RHEL/CentOS
-  * `sudo install rrdtool`
+* RHEL/CentOS 6.x
+  * Add `epel` repository, then `sudo yum install rrdtool rrdtool-devel`
 * Ubuntu
   * `sudo apt-get rrdtool`
 * OSX


### PR DESCRIPTION
yum install rrdtool rrdtool-devel

For centos5, we will get some troubles like that [rrdtool version is old](https://gist.github.com/sonots/8661761), and [sqlite version is old](http://blog.livedoor.jp/sonots/archives/29328032.html), so I noted as RHEL/CentOS 6.x
