### PR TITLE
Fix color update

### DIFF
--- a/lib/focuslight/data.rb
+++ b/lib/focuslight/data.rb
@@ -110,7 +110,7 @@ class Focuslight::Data
           number += graph.number
         end
         if mode != 'modified' || (mode == 'modified' && graph.number != number)
-          color ||= graph.color
+          color = graph.color if color.empty?
           db.execute(
             'UPDATE graphs SET number=?, mode=?, color=?, updated_at=? WHERE id = ?',
             [number, mode, color, Time.now.to_i, graph.id]


### PR DESCRIPTION
When updating a graph via /api/:service_name/:section_name/:graph_name
without params[:color], req_params[:color] isn't nil but empty string.
