### PR TITLE
Fix hash key

### DIFF
--- a/lib/focuslight/rrd.rb
+++ b/lib/focuslight/rrd.rb
@@ -157,7 +157,7 @@ class Focuslight::RRD
   def graph(datas, args)
     datas = [datas] unless datas.is_a?(Array)
     a_gmode = args[:gmode]
-    span = args.fetch('t', 'd')
+    span = args.fetch(:t, :d)
     from = args[:from]
     to = args[:to]
     width = args.fetch(:width, 390)


### PR DESCRIPTION
argsの中身はsymbolでの指定ですが、stringでfetchしているため、全てのパターンで返り値が'd'になっていました。
そのため、期間指定機能が正常に動作していません。
