### PR TITLE
fix graph_id typo

### DIFF
--- a/lib/focuslight/web.rb
+++ b/lib/focuslight/web.rb
@@ -427,7 +427,7 @@ class Focuslight::Web < Sinatra::Base
 
     data = []
     request.stash[:graph].data_rows.each do |row|
-      g = data().get_by_id(row[:graphid])
+      g = data().get_by_id(row[:graph_id])
       g.c_type = row[:type]
       g.c_gmode = row[:gmode]
       g.stack = row[:stack]
@@ -443,7 +443,7 @@ class Focuslight::Web < Sinatra::Base
 
     data = []
     request.stash[:graph].data_rows.each do |row|
-      g = data().get_by_id(row[:graphid])
+      g = data().get_by_id(row[:graph_id])
       g.c_type = row[:type]
       g.c_gmode = row[:gmode]
       g.stack = row[:stack]


### PR DESCRIPTION
APIで取得した場合(from yohoushi)にcomplex graphが表示されないバグの改修です。

細かくロジックは追ってないのですが、なぜかfocuslightのGUIからだとcomplex graph表示が出てきているのが不思議。。。（GUIの場合、ここのURI、使ってない？)
