### PR TITLE
fix edit graph

### DIFF
--- a/lib/focuslight/web.rb
+++ b/lib/focuslight/web.rb
@@ -623,7 +623,7 @@ class Focuslight::Web < Sinatra::Base
       halt 404
     end
 
-    spec = JSON.parse(request.body || '{}', symbolize_names: true)
+    spec = JSON.parse(request.body.read || '{}', symbolize_names: true)
     id = spec.delete(:id) || graph.id
 
     if spec.has_key?(:data)


### PR DESCRIPTION
```
TypeError - no implicit conversion of Unicorn::TeeInput into String:
```

was raised. `response.body` is usually IO object (Unicorn::TeeInput object in the case of unicorn, though), so `read` is necessary. 
