### PR TITLE
fix get graph

### DIFF
--- a/lib/focuslight/web.rb
+++ b/lib/focuslight/web.rb
@@ -498,7 +498,7 @@ class Focuslight::Web < Sinatra::Base
   end
 
   get '/api/:service_name/:section_name/:graph_name', :graph => :simple do
-    json(request.hash[:graph].to_hash)
+    json(request.stash[:graph].to_hash)
   end
 
   post '/api/:service_name/:section_name/:graph_name' do


### PR DESCRIPTION
```
12:20:19 web.1     | TypeError - no implicit conversion of Symbol into Integer:
12:20:19 web.1     |    /home/seo.naotoshi/gitrepos/focuslight/lib/focuslight/web.rb:501:in `[]'
12:20:19 web.1     |    /home/seo.naotoshi/gitrepos/focuslight/lib/focuslight/web.rb:501:in `block in <class:Web>'
```

`hash[:graph]` should correctly be `stash[:graph]`. 
