### PR TITLE
fix get graph (again)

### DIFF
--- a/lib/focuslight/graph.rb
+++ b/lib/focuslight/graph.rb
@@ -133,7 +133,8 @@ module Focuslight
         ulimit: @ulimit, llimit: @llimit, sulimit: @sulimit, sllimit: @sllimit,
         type: @type, stype: @stype,
         adjust: @adjust, adjustval: @adjustval, unit: @unit,
-        complex: false
+        complex: false,
+        md5: @md5, meta: @meta,
       }
       hash = super
       hash.merge(simple)


### PR DESCRIPTION
growthforecast returns `md5` and `meta` parameter
