### PR TITLE
unicorn-worker-killler

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,4 +3,13 @@ require "sinatra"
 
 require File.expand_path '../lib/focuslight/web.rb', __FILE__
 
+# Unicorn self-process killer
+require 'unicorn/worker_killer'
+
+# Max requests per worker
+use Unicorn::WorkerKiller::MaxRequests, 3072, 4096
+
+# Max memory size (RSS) per worker
+use Unicorn::WorkerKiller::Oom, (192*(1024**2)), (256*(1024**2))
+
 run Focuslight::Web

--- a/focuslight.gemspec
+++ b/focuslight.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "sinatra-contrib"
   spec.add_runtime_dependency "erubis"
   spec.add_runtime_dependency "unicorn"
+  spec.add_runtime_dependency "unicorn-worker-killer"
 
   spec.add_runtime_dependency "sequel"
   spec.add_runtime_dependency "sqlite3"


### PR DESCRIPTION
For https://github.com/focuslight/focuslight/issues/18

This is to achieve

> And, Let me write additional notes here: GrowthForecast(Plack) respawns child processes after seving 100 requests as default. So, Even if it opens files everytime it will not address big issues. I think this is nice mechanism, in terms of reducing memory issues too, and this can be done using unicorn-worker-killer gem

I picked the default parameters by just copying from https://github.com/kzk/unicorn-worker-killer
