### PR TITLE
The right side graph has always been render to "Day (5min avg)"

### DIFF
--- a/lib/focuslight/web.rb
+++ b/lib/focuslight/web.rb
@@ -366,7 +366,7 @@ class Focuslight::Web < Sinatra::Base
     section_name: not_specified_or_not_whitespece,
     graph_name: not_specified_or_not_whitespece,
     complex: not_specified_or_not_whitespece,
-    t: { default: 'd', rule: rule(:choice, 'd', 'h', 'm', 'sh', 'sd') },
+    t: { default: 'd', rule: rule(:choice, %w(y m w 3d s3d d sd 8h s8h 4h s4h h sh n sn c sc)) },
     from: {
       default: (Time.now - 86400*8).strftime('%Y/%m/%d %T'),
       rule: rule(:lambda, ->(v){ Time.parse(v) rescue false }, "invalid time format"),


### PR DESCRIPTION
![hour 8hours 1min](https://cloud.githubusercontent.com/assets/916624/17654618/f6ea4d60-62df-11e6-96b8-ca834093bc1c.png)
![day 3days 1min](https://cloud.githubusercontent.com/assets/916624/17654620/fd592874-62df-11e6-90c0-a09d689ab53a.png)
![hour halfday](https://cloud.githubusercontent.com/assets/916624/17654624/0266b3ae-62e0-11e6-816e-e6046d3e680d.png)
![day week](https://cloud.githubusercontent.com/assets/916624/17654627/0635d690-62e0-11e6-8e2d-c69c04186832.png)
![month year](https://cloud.githubusercontent.com/assets/916624/17654628/08b8cd14-62e0-11e6-889a-5f5f931803e5.png)


By the way, it's GrowthForecast validation rule.

https://github.com/kazeburo/GrowthForecast/blob/master/lib/GrowthForecast/Web.pm#L464
```perl
...snip...
't' => {
    default => 'd',
    rule => [
        [['CHOICE',qw/y m w 3d s3d d sd 8h s8h 4h s4h h sh n sn c sc/],'invalid drawing term'],
    ],
},
...snip...
```